### PR TITLE
Add NLP datasets

### DIFF
--- a/research/readme.md
+++ b/research/readme.md
@@ -1,4 +1,4 @@
-# research-awesome-list [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Research-awesome-list [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 List of machine learning repositories and publication algorithms implementation. Inspired by
 [`awesome-machine-learning`](https://github.com/josephmisiti/awesome-machine-learning)
@@ -13,42 +13,42 @@ Also, a listed repository should be deprecated if:
 
 - [Repositories](#repositories)
 
-    - [Neural style transfer](#neural-style-transfer)
-    - [Model compression / knowledge distillation](#model-compression)
-    - [Attention](#attention)
     - [Architecture search](#architecture-search)
+    - [Attention](#attention)
+    - [Model compression / knowledge distillation](#model-compression)
     - [NLP](#natural-language-processing)
+    - [Neural style transfer](#neural-style-transfer)
 
 
 # Repositories
-
-## Neural style transfer
-
-- [Real Time Style Transfer](https://github.com/jsigee87/real-time-style-transfer) - PyTorch - A real time neural style transfer project for EE 461P Data Science Principles, at the University of Texas at Austin. This code is associated with the blog post [Real Time Video Neural Style Transfer](https://towardsdatascience.com/real-time-video-neural-style-transfer-9f6f84590832).
-
-- [Fast Neural Style](https://github.com/robertomest/neural-style-keras) - Keras - An implementation of neural style transfer methods using Keras and Tensorflow.
-
-## Model compression
-Here is a larger list of relevant publications and repositories: [Awesome list knowledge distillation](https://github.com/dkozlov/awesome-knowledge-distillation).
-
-- [Rocket Launching](https://github.com/zhougr1993/Rocket-Launching) - PyTorch - A universal and efficient framework for training well-performing light net [[paper]](https://arxiv.org/abs/1708.04106) 
-
-- [Knowledge Distillation PyTorch](https://github.com/peterliht/knowledge-distillation-pytorch) - PyTorch - An implementation for exploring deep and shallow knowledge distillation (KD) experiments with flexibility
-
-- [Data-free Knowledge Distillation for Deep Neural Networks](https://github.com/iRapha/replayed_distillation) - Tensorflow - Implementation of Data-free Knowledge Distillation for Deep Neural Networks.
-
-- [Knowledge distillation with Keras](https://github.com/TropComplique/knowledge-distillation-keras) - Keras - Keras implementation of Hinton's knowledge distillation (KD), a way of transferring knowledge from a large model into a smaller model.
-
-- [Quantized distillation](https://github.com/antspy/quantized_distillation) - PyTorch - An implementation of model compression and quantized distillation for the paper [[paper]](https://arxiv.org/abs/1802.05668)
-
-## Attention
-
-- [Attention Transfer](https://github.com/szagoruyko/attention-transfer) - PyTorch - code for "Paying More Attention to Attention: Improving the Performance of Convolutional Neural Networks via Attention Transfer" [[paper]](https://arxiv.org/abs/1612.03928)
 
 ## Architecture search
 
 - [Neural Architecture Search](https://github.com/carpedm20/ENAS-pytorch) - PyTorch - implementation of "Efficient Neural Architecture Search via Parameters Sharing" [[paper]](https://arxiv.org/abs/1802.03268)
 
+## Attention
+
+- [Attention Transfer](https://github.com/szagoruyko/attention-transfer) - PyTorch - code for "Paying More Attention to Attention: Improving the Performance of Convolutional Neural Networks via Attention Transfer" [[paper]](https://arxiv.org/abs/1612.03928)
+
+## Model compression
+Here is a larger list of relevant publications and repositories: [Awesome list knowledge distillation](https://github.com/dkozlov/awesome-knowledge-distillation).
+
+- [Data-free Knowledge Distillation for Deep Neural Networks](https://github.com/iRapha/replayed_distillation) - Tensorflow - Implementation of Data-free Knowledge Distillation for Deep Neural Networks.
+
+- [Knowledge Distillation PyTorch](https://github.com/peterliht/knowledge-distillation-pytorch) - PyTorch - An implementation for exploring deep and shallow knowledge distillation (KD) experiments with flexibility
+
+- [Knowledge distillation with Keras](https://github.com/TropComplique/knowledge-distillation-keras) - Keras - Keras implementation of Hinton's knowledge distillation (KD), a way of transferring knowledge from a large model into a smaller model.
+
+- [Quantized distillation](https://github.com/antspy/quantized_distillation) - PyTorch - An implementation of model compression and quantized distillation for the paper [[paper]](https://arxiv.org/abs/1802.05668)
+
+- [Rocket Launching](https://github.com/zhougr1993/Rocket-Launching) - PyTorch - A universal and efficient framework for training well-performing light net [[paper]](https://arxiv.org/abs/1708.04106) 
+
 ## Natural Language Processing
 
 - [Datasets for NLP](https://github.com/AcademiaSinicaNLPLab/sentiment_dataset) - contains Movie Reviews (MR), Stanford Sentiment Treebank (SST), Subjectivity dataset (Subj), TREC question dataset (TREC-6), and Customer Reviews dataset (CR).
+
+## Neural style transfer
+
+- [Fast Neural Style](https://github.com/robertomest/neural-style-keras) - Keras - An implementation of neural style transfer methods using Keras and Tensorflow.
+
+- [Real Time Style Transfer](https://github.com/jsigee87/real-time-style-transfer) - PyTorch - A real time neural style transfer project for EE 461P Data Science Principles, at the University of Texas at Austin. This code is associated with the blog post [Real Time Video Neural Style Transfer](https://towardsdatascience.com/real-time-video-neural-style-transfer-9f6f84590832).


### PR DESCRIPTION
# Tool

Here I add a repository containing multiple text-based datasets, since it is tricky sometimes to find a suitable one. The authors provide scripts to convert data to DataFrames, if needed.

| Name | Repository | Author | Project Page |
| ---- | ---------- | ------ | ------------ |
| AcademiaSinicaNLPLab |[link](https://github.com/AcademiaSinicaNLPLab/sentiment_dataset)| AcademiaSinicaNLPLab |  --- |

# Reason of Change

- [X] New tool to review (please review the tool along with the CR)
- [ ] Verified new tool to merge (I used it already)
- [ ] Tool deprecated / no longer maintained
- [ ] Tool details changed (project page moved, etc.)
- [ ] Repository maintenance

# Purpose

It provides an easy access to download NLP datasets.
