### PR TITLE
Add pytorch-transformers to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ processing, ODE solvers, and more.
 library, built on PyTorch.
 - [PyText](https://github.com/facebookresearch/pytext) - A natural language
 modeling framework based on PyTorch by Facebook Research
+- [pytorch-transformers](https://github.com/huggingface/pytorch-transformers) -
+A library of state-of-the-art pretrained models for (NLP) including BERT, GPT,
+GPT-2, Transformer-XL, XLNet and XLM with multiple pre-trained model weights 
 - [flair](https://github.com/zalandoresearch/flair) - A very simple framework
 for state-of-the-art Natural Language Processing (NLP) by Zalando Research
 


### PR DESCRIPTION
# Tool

:grey_exclamation: Provide necessary minimal information.

| Name | Repository | Author | Project Page |
| ---- | ---------- | ------ | ------------ |
|PyTorch-Transformers|  [repo](https://github.com/huggingface/pytorch-transformers) | [huggingface -NLP company](https://huggingface.co/)|[docs](https://huggingface.co/pytorch-transformers/)|

# Reason of Change

- [x] New tool to review (please review the tool along with the CR)
- [ ] Verified new tool to merge (I used it already)
- [ ] Tool deprecated / no longer maintained
- [ ] Tool details changed (project page moved, etc.)
- [ ] Repository maintenance

# Purpose

:grey_question: What is the purpose of the tool? How could it help us?
This is a repository with over 8k stars for now, it has been lately [released in stable version 1.0](https://github.com/huggingface/pytorch-transformers/releases/tag/v1.0.0), have at this point 6 SOTA NLP models (including BERT), with 27 pre-trained weights and a unified API for all of them.
Think since we are going to invest some time in NLP, think we should definitely check this out.
